### PR TITLE
Handle DST in alarm scheduler

### DIFF
--- a/neocontrol.py
+++ b/neocontrol.py
@@ -14,6 +14,7 @@ app = Flask(__name__, static_folder='static', static_url_path='')
 
 # Load alarm data from the file, or set the default alarm
 ALARM_FILE = "alarm.json"
+TIMEZONE = os.environ.get("TIMEZONE", os.environ.get("TZ", "UTC"))
 DEFAULT_DAYS = [
     "monday",
     "tuesday",
@@ -114,7 +115,7 @@ def schedule_alarm():
         schedule.cancel_job(job)
     alarm_schedulers = []
     for day in alarm_data["days"]:
-        job = getattr(schedule.every(), day).at(alarm_data["time"]).do(alarm_triggered)
+        job = getattr(schedule.every(), day).at(alarm_data["time"], tz=TIMEZONE).do(alarm_triggered)
         alarm_schedulers.append(job)
 
 schedule_alarm()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ schedule
 gunicorn
 rpi_ws281x
 PyJWT
+pytz
 numpy


### PR DESCRIPTION
## Summary
- allow timezone-aware scheduling
- install pytz to let schedule handle DST properly

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f3ec02b4832cb8999ba6165974d4